### PR TITLE
Use bit mixing for safety

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 Next version:
 
+- Use bit mixing (@polytypic)
 - Change `find` to use `raise_notrace` for performance (@polytypic)
 - Change license to ISC from 0BSD (@tarides)
 

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,20 @@
 (library
  (name Thread_table)
  (public_name thread-table))
+
+(rule
+ (targets mix.ml)
+ (deps mix.64.ml)
+ (enabled_if %{arch_sixtyfour})
+ (action
+  (progn
+   (copy mix.64.ml mix.ml))))
+
+(rule
+ (targets mix.ml)
+ (deps mix.32.ml)
+ (enabled_if
+  (not %{arch_sixtyfour}))
+ (action
+  (progn
+   (copy mix.32.ml mix.ml))))

--- a/src/mix.32.ml
+++ b/src/mix.32.ml
@@ -1,0 +1,15 @@
+(* Mixing function proposed by "TheIronBorn" in a Github issue
+
+     https://github.com/skeeto/hash-prospector/issues/19
+
+   in the repository of Hash Prospector by Chris Wellons.
+
+   Note that the mixing function was originally designed for 32-bit unsigned
+   integers. *)
+
+let[@inline] int x =
+  let x = x lxor (x lsr 16) in
+  let x = x * 0x21f0aaad in
+  let x = x lxor (x lsr 15) in
+  let x = x * 0x735a2d97 in
+  x lxor (x lsr 15)

--- a/src/mix.64.ml
+++ b/src/mix.64.ml
@@ -1,0 +1,13 @@
+(* Mixing function proposed by Jon Maiga:
+
+     https://jonkagstrom.com/mx3/mx3_rev2.html
+
+   Note that the mixing function was originally designed for 64-bit unsigned
+   integers. *)
+
+let[@inline] int x =
+  let x = x lxor (x lsr 32) in
+  let x = x * 0xe9846af9b1a615d in
+  let x = x lxor (x lsr 32) in
+  let x = x * 0xe9846af9b1a615d in
+  x lxor (x lsr 28)


### PR DESCRIPTION
This PR adds bit mixing (i.e. hashing) of the integer keys.

This should make it less likely that an application would happen to use keys with a distribution that leads to very poor performance of the hash table.

However, for the intended use case of mapping thread ids to thread specific state, this likely makes performance slightly worse, because, in the OCaml runtime, thread ids are allocated using a simple FAA counter.